### PR TITLE
msm8998: Remove timeservice_app_cert certificate

### DIFF
--- a/msm8998-common/Android.bp
+++ b/msm8998-common/Android.bp
@@ -266,7 +266,6 @@ android_app_import {
 	name: "TimeService",
 	owner: "oneplus",
 	apk: "proprietary/vendor/app/TimeService/TimeService.apk",
-	certificate: ":timeservice_app_cert-legacy-um",
 	dex_preopt: {
 		enabled: false,
 	},


### PR DESCRIPTION
* This cert was removed in R qcom sepolicy...

error: vendor/oneplus/msm8998-common/Android.bp:265:1: "TimeService" depends on undefined module "timeservice_app_cert-legacy-um"

Change-Id: Iddd73a0c0a8bb9da224e62c262f7e6297772f152
Signed-off-by: NurKeinNeid <mralexman3000@gmail.com>